### PR TITLE
Upgrade alpine. CVE-2019-14697

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go get -u github.com/Masterminds/glide && \
 RUN cd statik && go generate && cd ..
 RUN go build -o /kuberos ./cmd/kuberos
 
-FROM alpine:3.7
+FROM alpine:3.19
 MAINTAINER Nic Cope <n+docker@rk0n.org>
 
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
Original image vulnerable by  `CVE-2019-14697`. 
Just upgraded alpine